### PR TITLE
Inserção do arquivo eslint, para auxiliar no desenvolvimento de um código limpo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,39 @@
+module.exports = {
+  root: true,
+  parser: 'babel-eslint',
+  parserOptions: {
+    sourceType: 'module'
+  },
+  env: {
+    browser: true
+  },
+  // https://github.com/feross/standard/blob/master/RULES.md#javascript-standard-style
+  extends: [
+    'standard'
+  ],
+  // required to lint *.vue files
+  plugins: [
+    'html',
+    'import'
+  ],
+  globals: {
+    'cordova': true,
+    'DEV': true,
+    'PROD': true,
+    '__THEME': true
+  },
+  // add your custom rules here
+  'rules': {
+    // allow paren-less arrow functions
+    'arrow-parens': 0,
+    'one-var': 0,
+    'import/first': 0,
+    'import/named': 2,
+    'import/namespace': 2,
+    'import/default': 2,
+    'import/export': 2,
+    // allow debugger during development
+    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
+    'brace-style': [2, 'stroustrup', { 'allowSingleLine': true }]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ plugins/*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.idea/


### PR DESCRIPTION
Inserção do arquivo eslintrc.js, para auxiliar no desenvolvimento de um código limpo dentro dos padrões da ECMAscript, visto que algumas IDE utilizam esse arquivo para auxiliar o desenvolvimento. E nas dependências de desenvolvimento vi que tinha pacotes eslint instalados, porém, o arquivo principal não existia ou está em alguma pasta desconhecida, pois as IDE´s que utilizei para teste não encontrou o arquivo.